### PR TITLE
Do not use persistent status sections for status messages

### DIFF
--- a/sublack/blacker.py
+++ b/sublack/blacker.py
@@ -283,7 +283,7 @@ class Black:
             self.view.window().status_message(error_message)
             return returncode
 
-        # already formated, nothing changes
+        # already formatted, nothing changes
         elif "unchanged" in error_message:
             self.view.window().status_message(consts.ALREADY_FORMATTED_MESSAGE)
             self.add_to_cache(content, command)

--- a/sublack/blacker.py
+++ b/sublack/blacker.py
@@ -280,12 +280,12 @@ class Black:
         self.log.debug(f"Black returned: {error_message}")
         # failure
         if returncode != 0:
-            self.view.set_status(consts.STATUS_KEY, error_message)
+            self.view.window().status_message(error_message)
             return returncode
 
         # already formated, nothing changes
         elif "unchanged" in error_message:
-            self.view.set_status(consts.STATUS_KEY, consts.ALREADY_FORMATTED_MESSAGE)
+            self.view.window().status_message(consts.ALREADY_FORMATTED_MESSAGE)
             self.add_to_cache(content, command)
 
         # diff mode
@@ -311,7 +311,7 @@ class Black:
             self.view.sel().add(old_sel)
 
             # status and caching
-            self.view.set_status(consts.STATUS_KEY, consts.REFORMATTED_MESSAGE)
+            self.view.window().status_message(consts.REFORMATTED_MESSAGE)
             sublime.set_timeout_async(lambda: self.add_to_cache(new_content, command))
 
     def format_via_precommit(self, edit: sublime.Edit, content, cwd, env):
@@ -378,7 +378,7 @@ class Black:
         # check the cache
         # cache may not be used with pre-commit
         if self.is_cached(content, command):
-            self.view.set_status(consts.STATUS_KEY, consts.ALREADY_FORMATTED_MESSAGE_CACHE)
+            self.view.window().status_message(consts.ALREADY_FORMATTED_MESSAGE_CACHE)
             return
 
         if use_blackd:
@@ -500,16 +500,9 @@ class BlackAll:
             if success_list
             else consts.REFORMAT_ERRORS
         )
-        # if success_list and error_list:
-        #     error_message = consts.REFORMATTED_ALL_PARTIAL_MESSAGE
+        if window := self.view.window():
+            window.status_message(error_message)
 
-        # elif success_list:
-        #     error_message = consts.REFORMATTED_ALL_MESSAGE
-
-        # else:
-        #     error_message = consts.REFORMAT_ERRORS
-
-        self.view.set_status(consts.STATUS_KEY, error_message)
         for result in success_list:
             folder, code, output = result
             self.log.debug(

--- a/sublack/commands.py
+++ b/sublack/commands.py
@@ -121,9 +121,9 @@ class BlackdStopCommand(sublime_plugin.ApplicationCommand):
         view = sublime.active_window().active_view()
         assert view, "No view found!"
         if server.stop_blackd_server():
-            view.set_status(consts.STATUS_KEY, consts.BLACKD_STOPPED)
+            sublime.active_window().status_message(consts.BLACKD_STOPPED)
         else:
-            view.set_status(consts.STATUS_KEY, consts.BLACKD_STOP_FAILED)
+            sublime.active_window().status_message(consts.BLACKD_STOP_FAILED)
 
 
 class BlackFormatAllCommand(sublime_plugin.WindowCommand):


### PR DESCRIPTION
Initially the plugin used `window.status_message`s which disappear
after a few seconds.  A persistent message like "sublack: reformatted"
which doesn't even go away when editing the file is not helpful.

Persistent messages for the daemon *on the view* are also a mistake
as they stick to the view although the daemon has been probably started
for the window.  Make them non-sticky as well.